### PR TITLE
fix: 보안그룹 수정

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  #profile = "terraform-user"
+#   profile = "terraform-user"
   region  = var.region
   assume_role {
     role_arn = "arn:aws:iam::851725627278:role/TerraformAssumedRole"
@@ -18,6 +18,9 @@ module "vpc" {
 module "security_groups" {
   source = "./modules/security_groups"
   vpc_id = module.vpc.vpc_id
+  vpc_cidr = var.vpc_cidr
+  public_subnet_a_cidr = var.public_subnet_a_cidr
+  public_subnet_c_cidr = var.public_subnet_c_cidr
 }
 
 module "instances" {
@@ -27,7 +30,8 @@ module "instances" {
   key_name           = var.key_name
   public_subnet_a_id = module.vpc.public_subnet_a_id
   public_subnet_c_id = module.vpc.public_subnet_c_id
-  security_group_id  = module.security_groups.security_group_id
+  master_security_group_id  = module.security_groups.ktb_11_chatbot_master_sg_id
+  worker_security_group_id = module.security_groups.ktb_11_chatbot_worker_sg_id
 }
 
 module "rds" {
@@ -37,5 +41,5 @@ module "rds" {
   db_password        = var.db_password
   private_subnet_a_id = module.vpc.private_subnet_a_id
   private_subnet_c_id = module.vpc.private_subnet_c_id
-  security_group_id  = module.security_groups.security_group_id
+  security_group_id  = module.security_groups.ktb_11_chatbot_rds_sg_id
 }

--- a/terraform/modules/instances/main.tf
+++ b/terraform/modules/instances/main.tf
@@ -2,7 +2,7 @@ resource "aws_instance" "ktb_11_chatbot_master" {
   ami           = var.ami
   instance_type = var.instance_type
   subnet_id     = var.public_subnet_a_id
-  security_groups = [var.security_group_id]
+  security_groups = [var.master_security_group_id]
   key_name      = var.key_name
 
   tags = {
@@ -14,7 +14,7 @@ resource "aws_instance" "ktb_11_chatbot_worker1" {
   ami           = var.ami
   instance_type = var.instance_type
   subnet_id     = var.public_subnet_a_id
-  security_groups = [var.security_group_id]
+  security_groups = [var.worker_security_group_id]
   key_name      = var.key_name
 
   tags = {
@@ -26,7 +26,7 @@ resource "aws_instance" "ktb_11_chatbot_worker2" {
   ami           = var.ami
   instance_type = var.instance_type
   subnet_id     = var.public_subnet_c_id
-  security_groups = [var.security_group_id]
+  security_groups = [var.worker_security_group_id]
   key_name      = var.key_name
 
   tags = {
@@ -37,8 +37,8 @@ resource "aws_instance" "ktb_11_chatbot_worker2" {
 resource "aws_instance" "ktb_11_chatbot_worker3" {
   ami           = var.ami
   instance_type = var.instance_type
-  subnet_id     = var.public_subnet_a_id
-  security_groups = [var.security_group_id]
+  subnet_id     = var.public_subnet_c_id
+  security_groups = [var.worker_security_group_id]
   key_name      = var.key_name
 
   tags = {

--- a/terraform/modules/instances/variables.tf
+++ b/terraform/modules/instances/variables.tf
@@ -23,7 +23,12 @@ variable "public_subnet_c_id" {
   type        = string
 }
 
-variable "security_group_id" {
-  description = "The ID of the security group"
+variable "master_security_group_id" {
+  description = "The ID of the master security group"
+  type        = string
+}
+
+variable "worker_security_group_id" {
+  description = "The ID of the worker security group"
   type        = string
 }

--- a/terraform/modules/security_groups/main.tf
+++ b/terraform/modules/security_groups/main.tf
@@ -1,6 +1,7 @@
-resource "aws_security_group" "ktb_11_chatbot_sg" {
+resource "aws_security_group" "ktb_11_chatbot_master_sg" {
   vpc_id = var.vpc_id
 
+  # SSH 접근을 허용
   ingress {
     from_port   = 22
     to_port     = 22
@@ -8,48 +9,50 @@ resource "aws_security_group" "ktb_11_chatbot_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-#   ingress {
-#     from_port   = 443
-#     to_port     = 443
-#     protocol    = "tcp"
-#     cidr_blocks = ["0.0.0.0/0"]
-#   }
-
+  # Kubernetes API 서버 접근을 특정 서브넷으로 제한
   ingress {
     from_port   = 6443
     to_port     = 6443
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [
+      var.public_subnet_a_cidr,
+      var.public_subnet_c_cidr
+    ]
   }
 
+  # etcd 서버 클라이언트 API 접근 허용 (마스터 노드에만 필요)
+  ingress {
+    from_port   = 2379
+    to_port     = 2380
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]  # 마스터 노드 내 통신만 허용
+  }
+
+  # Kubelet API 접근 허용
   ingress {
     from_port   = 10250
     to_port     = 10250
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.vpc_cidr]
   }
 
+  # kube-controller-manager 접근 허용 (마스터 노드에만 필요)
   ingress {
-    from_port   = 30000
-    to_port     = 32767
+    from_port   = 10257
+    to_port     = 10257
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.vpc_cidr]
   }
 
+  # kube-scheduler 접근 허용 (마스터 노드에만 필요)
   ingress {
-    from_port   = 3306
-    to_port     = 3306
+    from_port   = 10259
+    to_port     = 10259
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.vpc_cidr]
   }
 
+  # 모든 아웃바운드 트래픽 허용
   egress {
     from_port   = 0
     to_port     = 0
@@ -58,6 +61,112 @@ resource "aws_security_group" "ktb_11_chatbot_sg" {
   }
 
   tags = {
-    Name = "ktb-11-chatbot-sg"
+    Name = "ktb-11-chatbot-master-sg"
   }
+}
+
+resource "aws_security_group" "ktb_11_chatbot_worker_sg" {
+  vpc_id = var.vpc_id
+
+  # SSH 접근을 허용
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Kubelet API 접근 허용
+  ingress {
+    from_port   = 10250
+    to_port     = 10250
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  # NodePort 서비스 접근 허용 (모든 워커 노드에 필요)
+  ingress {
+    from_port   = 30000
+    to_port     = 32767
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # 모든 아웃바운드 트래픽 허용
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "ktb-11-chatbot-worker-sg"
+  }
+}
+
+resource "aws_security_group" "ktb_11_chatbot_rds_sg" {
+  vpc_id = var.vpc_id
+
+  # 모든 아웃바운드 트래픽 허용
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "ktb-11-chatbot-rds-sg"
+  }
+}
+
+# 마스터 노드에서 워커 노드로의 통신 허용
+resource "aws_security_group_rule" "master_to_worker" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.ktb_11_chatbot_worker_sg.id
+  source_security_group_id = aws_security_group.ktb_11_chatbot_master_sg.id
+}
+
+# 워커 노드에서 마스터 노드로의 통신 허용
+resource "aws_security_group_rule" "worker_to_master" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.ktb_11_chatbot_master_sg.id
+  source_security_group_id = aws_security_group.ktb_11_chatbot_worker_sg.id
+}
+
+# 워커 노드 간의 모든 포트 통신 허용
+resource "aws_security_group_rule" "worker_sg_self" {
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.ktb_11_chatbot_worker_sg.id
+  source_security_group_id = aws_security_group.ktb_11_chatbot_worker_sg.id
+}
+
+# RDS와 마스터 노드 간의 MySQL 포트 통신 허용
+resource "aws_security_group_rule" "rds_master_sg_ingress" {
+  type                     = "ingress"
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.ktb_11_chatbot_rds_sg.id
+  source_security_group_id = aws_security_group.ktb_11_chatbot_master_sg.id
+}
+
+# RDS와 워커 노드 간의 MySQL 포트 통신 허용
+resource "aws_security_group_rule" "rds_worker_sg_ingress" {
+  type                     = "ingress"
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.ktb_11_chatbot_rds_sg.id
+  source_security_group_id = aws_security_group.ktb_11_chatbot_worker_sg.id
 }

--- a/terraform/modules/security_groups/outputs.tf
+++ b/terraform/modules/security_groups/outputs.tf
@@ -1,3 +1,11 @@
-output "security_group_id" {
-  value = aws_security_group.ktb_11_chatbot_sg.id
+output "ktb_11_chatbot_master_sg_id" {
+  value = aws_security_group.ktb_11_chatbot_master_sg.id
+}
+
+output "ktb_11_chatbot_worker_sg_id" {
+  value = aws_security_group.ktb_11_chatbot_worker_sg.id
+}
+
+output "ktb_11_chatbot_rds_sg_id" {
+  value = aws_security_group.ktb_11_chatbot_rds_sg.id
 }

--- a/terraform/modules/security_groups/variables.tf
+++ b/terraform/modules/security_groups/variables.tf
@@ -2,3 +2,18 @@ variable "vpc_id" {
   description = "The ID of the VPC"
   type        = string
 }
+
+variable "public_subnet_a_cidr" {
+  description = "The CIDR block for the public subnet in availability zone a"
+  type        = string
+}
+
+variable "public_subnet_c_cidr" {
+  description = "The CIDR block for the public subnet in availability zone c"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "The CIDR block for the VPC"
+  type        = string
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -23,9 +23,19 @@ output "private_subnet_c_id" {
   value       = module.vpc.private_subnet_c_id
 }
 
-output "security_group_id" {
-  description = "The ID of the security group"
-  value       = module.security_groups.security_group_id
+output "instance_master_security_group_id" {
+  description = "The ID of the instance security group"
+  value       = module.security_groups.ktb_11_chatbot_master_sg_id
+}
+
+output "instance_worker_security_group_id" {
+  description = "The ID of the instance security group"
+  value       = module.security_groups.ktb_11_chatbot_worker_sg_id
+}
+
+output "rds_security_group_id" {
+  description = "The ID of the RDS security group"
+  value       = module.security_groups.ktb_11_chatbot_rds_sg_id
 }
 
 output "master_instance_id" {


### PR DESCRIPTION
### 📝 작업한 내용
- **Kubernetes 포트 개방**: 보안 그룹에서 Kubernetes 마스터 노드 및 워커 노드 간의 통신을 허용하기 위해 다음과 같은 포트 규칙을 추가
  - **etcd 서버 클라이언트 API 포트**: `2379-2380` (마스터 노드 내부 통신만 허용).
  - **Kubelet API 포트**: `10250` (마스터 및 워커 노드에서 허용).
  - **kube-controller-manager 포트**: `10257` (마스터 노드 내부 통신만 허용).
  - **kube-scheduler 포트**: `10259` (마스터 노드 내부 통신만 허용).
  - **NodePort 서비스 포트**: `30000-32767` (모든 워커 노드에서 외부 접근을 허용).
  
- **보안 그룹 분리**: 기존 하나의 보안 그룹에서 **마스터 노드**, **워커 노드**, **RDS**로 분리

### 🛠️ 추후 작업할 내용
- 배포 단테 진행
