### PR TITLE
add: load balancer, iam role 추가

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,9 +1,13 @@
 provider "aws" {
-#   profile = "terraform-user"
+  profile = "terraform-user"
   region  = var.region
   assume_role {
     role_arn = "arn:aws:iam::851725627278:role/TerraformAssumedRole"
   }
+}
+
+module "iam_roles" {
+  source = "./modules/iam_roles"
 }
 
 module "vpc" {
@@ -32,6 +36,8 @@ module "instances" {
   public_subnet_c_id = module.vpc.public_subnet_c_id
   master_security_group_id  = module.security_groups.ktb_11_chatbot_master_sg_id
   worker_security_group_id = module.security_groups.ktb_11_chatbot_worker_sg_id
+  master_instance_profile_name = module.iam_roles.master_instance_profile
+  worker_instance_profile_name = module.iam_roles.worker_instance_profile
 }
 
 module "rds" {
@@ -42,4 +48,31 @@ module "rds" {
   private_subnet_a_id = module.vpc.private_subnet_a_id
   private_subnet_c_id = module.vpc.private_subnet_c_id
   security_group_id  = module.security_groups.ktb_11_chatbot_rds_sg_id
+}
+
+module "load_balancer" {
+  source             = "./modules/load_balancer"
+  lb_name            = "ktb-11-chatbot-lb"
+  vpc_id             = module.vpc.vpc_id
+  subnets            = [module.vpc.public_subnet_a_id, module.vpc.public_subnet_c_id]
+  security_groups    = [module.security_groups.ktb_11_chatbot_worker_sg_id]
+  target_group_name  = "ktb-11-chatbot-tg"
+  target_group_port  = 30001
+  instance_ids       = [
+    module.instances.worker1_instance_id,
+    module.instances.worker2_instance_id,
+    module.instances.worker3_instance_id
+  ]
+}
+
+resource "aws_route53_record" "chatbot_alb" {
+  zone_id = var.route53_zone_id
+  name    = "ktb-chatbot.shop"
+  type    = "A"
+
+  alias {
+    name                   = module.load_balancer.alb_dns_name
+    zone_id                = module.load_balancer.alb_zone_id
+    evaluate_target_health = true
+  }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  profile = "terraform-user"
+#   profile = "terraform-user"
   region  = var.region
   assume_role {
     role_arn = "arn:aws:iam::851725627278:role/TerraformAssumedRole"

--- a/terraform/modules/iam_roles/main.tf
+++ b/terraform/modules/iam_roles/main.tf
@@ -1,0 +1,111 @@
+resource "aws_iam_role" "master_role" {
+  name = var.master_role_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "master_policy" {
+  name   = "ktb_11_chatbot_master_policy"
+  role   = aws_iam_role.master_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = [
+          "autoscaling:DescribeAutoScalingGroups",
+          "autoscaling:DescribeLaunchConfigurations",
+          "autoscaling:DescribeTags",
+          "ec2:DescribeInstances",
+          "ec2:DescribeRegions",
+          "ec2:DescribeRouteTables",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVolumes",
+          "ec2:CreateSecurityGroup",
+          "ec2:CreateTags",
+          "ec2:CreateVolume",
+          "ec2:ModifyInstanceAttribute",
+          "ec2:ModifyVolume",
+          "ec2:AttachVolume",
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:CreateRoute",
+          "ec2:DeleteRoute",
+          "ec2:DeleteSecurityGroup",
+          "ec2:DeleteVolume",
+          "ec2:DetachVolume",
+          "ec2:RevokeSecurityGroupIngress",
+          "ec2:DescribeVpcs",
+          "elasticloadbalancing:*",
+          "iam:CreateServiceLinkedRole",
+          "kms:DescribeKey"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "worker_role" {
+  name = var.worker_role_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "worker_policy" {
+  name   = "ktb_11_chatbot_worker_policy"
+  role   = aws_iam_role.worker_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = [
+          "ec2:DescribeInstances",
+          "ec2:DescribeRegions",
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:GetRepositoryPolicy",
+          "ecr:DescribeRepositories",
+          "ecr:ListImages",
+          "ecr:BatchGetImage"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}
+resource "aws_iam_instance_profile" "master_instance_profile" {
+  name = "ktb_11_chatbot_master_instance_profile"
+  role = aws_iam_role.master_role.name
+}
+
+resource "aws_iam_instance_profile" "worker_instance_profile" {
+  name = "ktb_11_chatbot_worker_instance_profile"
+  role = aws_iam_role.worker_role.name
+}

--- a/terraform/modules/iam_roles/outputs.tf
+++ b/terraform/modules/iam_roles/outputs.tf
@@ -1,0 +1,7 @@
+output "master_instance_profile" {
+  value       = aws_iam_instance_profile.master_instance_profile.name
+}
+
+output "worker_instance_profile" {
+  value       = aws_iam_instance_profile.worker_instance_profile.name
+}

--- a/terraform/modules/iam_roles/variables.tf
+++ b/terraform/modules/iam_roles/variables.tf
@@ -1,0 +1,11 @@
+variable "master_role_name" {
+  description = "The name of the master node IAM role"
+  type        = string
+  default     = "ktb_11_chatbot_master_role"
+}
+
+variable "worker_role_name" {
+  description = "The name of the worker node IAM role"
+  type        = string
+  default     = "ktb_11_chatbot_worker_role"
+}

--- a/terraform/modules/instances/main.tf
+++ b/terraform/modules/instances/main.tf
@@ -4,10 +4,17 @@ resource "aws_instance" "ktb_11_chatbot_master" {
   subnet_id     = var.public_subnet_a_id
   security_groups = [var.master_security_group_id]
   key_name      = var.key_name
+  iam_instance_profile = var.master_instance_profile_name
   user_data = <<-EOF
               #!/bin/bash
               hostnamectl set-hostname master
               EOF
+
+  root_block_device {
+    volume_size           = 10
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
 
   tags = {
     Name = "ktb-11-chatbot-master"
@@ -21,10 +28,17 @@ resource "aws_instance" "ktb_11_chatbot_worker1" {
   subnet_id     = var.public_subnet_c_id
   security_groups = [var.worker_security_group_id]
   key_name      = var.key_name
+  iam_instance_profile = var.worker_instance_profile_name
   user_data = <<-EOF
               #!/bin/bash
               hostnamectl set-hostname worker1
               EOF
+
+  root_block_device {
+    volume_size           = 10
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
 
   tags = {
     Name = "ktb-11-chatbot-worker1"
@@ -38,10 +52,17 @@ resource "aws_instance" "ktb_11_chatbot_worker2" {
   subnet_id     = var.public_subnet_c_id
   security_groups = [var.worker_security_group_id]
   key_name      = var.key_name
+  iam_instance_profile = var.worker_instance_profile_name
   user_data = <<-EOF
               #!/bin/bash
               hostnamectl set-hostname worker2
               EOF
+
+  root_block_device {
+    volume_size           = 10
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
 
   tags = {
     Name = "ktb-11-chatbot-worker2"
@@ -55,10 +76,17 @@ resource "aws_instance" "ktb_11_chatbot_worker3" {
   subnet_id     = var.public_subnet_c_id
   security_groups = [var.worker_security_group_id]
   key_name      = var.key_name
+  iam_instance_profile = var.worker_instance_profile_name
   user_data = <<-EOF
               #!/bin/bash
               hostnamectl set-hostname worker3
               EOF
+
+  root_block_device {
+    volume_size           = 10
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
 
   tags = {
     Name = "ktb-11-chatbot-worker3"

--- a/terraform/modules/instances/variables.tf
+++ b/terraform/modules/instances/variables.tf
@@ -32,3 +32,13 @@ variable "worker_security_group_id" {
   description = "The ID of the worker security group"
   type        = string
 }
+
+variable "master_instance_profile_name" {
+  description = "The name of the master master role"
+  type        = string
+}
+
+variable "worker_instance_profile_name" {
+  description = "The name of the worker master role"
+  type        = string
+}

--- a/terraform/modules/load_balancer/main.tf
+++ b/terraform/modules/load_balancer/main.tf
@@ -1,0 +1,50 @@
+resource "aws_lb" "ktb_11_chatbot_lb" {
+  name               = var.lb_name
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = var.security_groups
+  subnets            = var.subnets
+
+  tags = {
+    Name = var.lb_name
+  }
+}
+
+resource "aws_lb_target_group" "ktb_11_chatbot_tg" {
+  name     = var.target_group_name
+  port     = var.target_group_port
+  protocol = "HTTP"
+  vpc_id   = var.vpc_id
+  target_type = "instance"
+
+  health_check {
+    interval            = 30
+    path                = "/"
+    protocol            = "HTTP"
+    timeout             = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+
+  tags = {
+    Name = var.target_group_name
+  }
+}
+
+resource "aws_lb_listener" "ktb_11_chatbot_listener" {
+  load_balancer_arn = aws_lb.ktb_11_chatbot_lb.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.ktb_11_chatbot_tg.arn
+  }
+}
+
+resource "aws_lb_target_group_attachment" "ktb_11_chatbot_worker" {
+  count            = length(var.instance_ids)
+  target_group_arn = aws_lb_target_group.ktb_11_chatbot_tg.arn
+  target_id        = var.instance_ids[count.index]
+  port             = var.target_group_port
+}

--- a/terraform/modules/load_balancer/outputs.tf
+++ b/terraform/modules/load_balancer/outputs.tf
@@ -1,0 +1,7 @@
+output "alb_dns_name" {
+  value       = aws_lb.ktb_11_chatbot_lb.dns_name
+}
+
+output "alb_zone_id" {
+  value       = aws_lb.ktb_11_chatbot_lb.zone_id
+}

--- a/terraform/modules/load_balancer/variables.tf
+++ b/terraform/modules/load_balancer/variables.tf
@@ -1,0 +1,34 @@
+variable "lb_name" {
+  description = "ALB 이름"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "subnets" {
+  description = "서브넷 IDs"
+  type        = list(string)
+}
+
+variable "security_groups" {
+  description = "보안 그룹 IDs"
+  type        = list(string)
+}
+
+variable "target_group_name" {
+  description = "대상 그룹 이름"
+  type        = string
+}
+
+variable "target_group_port" {
+  description = "대상 그룹 포트"
+  type        = number
+}
+
+variable "instance_ids" {
+  description = "인스턴스 IDs"
+  type        = list(string)
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -58,3 +58,8 @@ variable "db_password" {
   description = "The password for the database"
   type = string
 }
+
+variable "route53_zone_id" {
+  description = "Route 53 호스팅 영역의 ID"
+  type        = string
+}


### PR DESCRIPTION
### 📝 작업한 내용
- 로드밸런서와 IAM 역할 관련 코드를 작성했습니다.
- IAM 역할은 각각 마스터와 워커 노드에 맞는 역할을 생성하여 인스턴스에 연결했습니다.
- 로드밸런서의 타겟 그룹에 워커 노드 1, 2, 3을 등록했습니다. (이 부분은 콘솔에서 통신 상태를 확인한 후, 정상적으로 동작하는 워커 노드만 다시 연결할 예정입니다.)
- 생성된 로드밸런서의 DNS를 사용해 호스팅 영역에 'ktb-chatbot.shop'의 A 레코드를 생성했습니다.
- 인스턴스 볼륨은 현재 10GB로 설정하였습니다.